### PR TITLE
Remove empty 'Operations' paragraph

### DIFF
--- a/docs/guide/variables.md
+++ b/docs/guide/variables.md
@@ -117,8 +117,6 @@ There are also several fake variables which aren't declared as local or global. 
 
 ## Operations
 
-Operations
-
 There are several mathematical operations you can perform on variables. Each operation must have the following syntax:
 
 ```c


### PR DESCRIPTION
The 'Operations' word is on a paragraph following the 'Operations' heading - appears to be a typo.